### PR TITLE
Implemented ansi coloring for the log viewer

### DIFF
--- a/embark/dashboard/views.py
+++ b/embark/dashboard/views.py
@@ -118,7 +118,7 @@ def show_log(request, analysis_id):
     log_file_path_ = f"{Path(firmware.path_to_logs).parent}/emba_run.log"
     logger.debug("Taking file at %s and render it", log_file_path_)
     try:
-        with open(log_file_path_, 'r', encoding='utf-8') as log_file_:
+        with open(log_file_path_, 'rb') as log_file_:
             return HttpResponse(content=log_file_, content_type="text/plain")
     except FileNotFoundError:
         return HttpResponseServerError(content="File is not yet available")

--- a/embark/static/content/css/logviewer.css
+++ b/embark/static/content/css/logviewer.css
@@ -1,0 +1,8 @@
+#logArea,
+#logArea * {
+    font-family: monospace;
+}
+
+#logArea {
+    line-height: 1.19;
+}

--- a/embark/templates/dashboard/logViewer.html
+++ b/embark/templates/dashboard/logViewer.html
@@ -2,6 +2,7 @@
 {% load static %}
 {% block title %}EMBArk Logs{% endblock title %}
 {% block navigation %}{% include "navigation.html" %}{% endblock navigation %}
+{% block style %}<link rel="stylesheet" type="text/css" href="{% static 'content/css/logviewer.css' %}"/>{% endblock style %}
 {% block maincontent %}
 <div class="col-sm">
     <div class="box">
@@ -55,5 +56,6 @@
 {% endblock maincontent %}
 {% block inlinejs %}
 <script>var analysis_id = "{{analysis_id}}";</script>
+<script type="module" src="{% static 'external/scripts/base64.js' %}"></script>
 <script type="text/javascript" src="{% static 'scripts/logViewer.js' %}"></script>
 {% endblock inlinejs %}

--- a/installer.sh
+++ b/installer.sh
@@ -344,6 +344,8 @@ install_embark_default(){
     wget -O ./embark/static/external/scripts/bootstrap.js https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js
     wget -O ./embark/static/external/scripts/datatable.js https://cdn.datatables.net/v/bs5/dt-1.11.2/datatables.min.js
     wget -O ./embark/static/external/scripts/charts.js https://cdn.jsdelivr.net/npm/chart.js@3.5.1/dist/chart.min.js
+    wget -O ./embark/static/external/scripts/base64.js https://cdn.jsdelivr.net/npm/js-base64@3.7.5/base64.min.js
+    wget -O ./embark/static/external/scripts/ansi_up.js https://cdn.jsdelivr.net/npm/ansi_up@6.0.2/ansi_up.min.js
     wget -O ./embark/static/external/css/confirm.css https://cdnjs.cloudflare.com/ajax/libs/jquery-confirm/3.3.2/jquery-confirm.min.css
     wget -O ./embark/static/external/css/bootstrap.css https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css
     wget -O ./embark/static/external/css/datatable.css https://cdn.datatables.net/v/bs5/dt-1.11.2/datatables.min.css


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Coloring in the log viewer


**What is the current behavior?** (You can also link to an open issue here)
Log viewer displays weird characters instead of ansi colors.


**What is the new behavior (if this is a feature change)? If possible add a screenshot.**
Log viewer parses the ansi colors and displays them accordingly.
![image](https://github.com/0x6368/embark/assets/7045209/ecc30058-78b9-4d89-b039-e46173dae5fa)



**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no


**Other information**:
---